### PR TITLE
Update for recent versions of Base, OCaml

### DIFF
--- a/lib/prettiest.ml
+++ b/lib/prettiest.ml
@@ -214,7 +214,7 @@ module Make (W : Width) : S = struct
   let text s = List.filter ~f:(MeasureText.valid W.width) [MeasureText.text s]
 
   let render xs =
-    List.min_elt xs ~cmp:MeasureText.compare |>
+    List.min_elt xs ~compare:MeasureText.compare |>
     Option.map ~f:MeasureText.render
 
   let fail = []

--- a/prettiest.opam
+++ b/prettiest.opam
@@ -11,9 +11,9 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base"
+  "base" {>= "v0.13.2"}
   "ppx_compare"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
   "jbuilder" {build & >= "1.0+beta12"}
 ]
 available: [ ocaml-version >= "4.04.1" ]


### PR DESCRIPTION
Update to support:
* recent versions of Base (tested with v0.13.2, v0.14.0)
* recent versions of OCaml (tested with 4.06.0, 4.11.1)